### PR TITLE
Remove B322 check

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@
 # NOTE: Bandit's file exclusion seems to be kind of busted: https://github.com/PyCQA/bandit/issues/488
 # Using Git to exclude test files instead for the PR check.
 
-BANDIT_CONFIGSTRING="--verbose -s B322" #Do not support Python2
+BANDIT_CONFIGSTRING="--verbose"
 FULLRUN_TARGET=${TARGET_DIR:-""}
 EXCLUDED=${BANDIT_EXCLUDE:-"*/tests/*,*/settings/local.py"}
 MSG_TEMPLATE="::error file={relpath},line={line}::[{test_id}] {msg}%0A(Severity: {severity}, Confidence: {confidence})%0AMore info: https://bandit.readthedocs.io/en/latest/search.html?q={test_id}"


### PR DESCRIPTION
bandit's latest release removed B322 check: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b322-input

changing this repo accordingly to avoid bandit checking failure